### PR TITLE
Respect namespace for the field

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -1032,8 +1032,11 @@ func parseEnumSchema(v map[string]interface{}, registry map[string]Schema, names
 	setOptionalField(&schema.Namespace, v, schemaNamespaceField)
 	setOptionalField(&schema.Doc, v, schemaDocField)
 	schema.Properties = getProperties(v)
-
-	return addSchema(getFullName(v[schemaNameField].(string), namespace), schema, registry), nil
+	ns := namespace
+	if schema.Namespace != "" {
+		ns = schema.Namespace
+	}
+	return addSchema(getFullName(v[schemaNameField].(string), ns), schema, registry), nil
 }
 
 func parseFixedSchema(v map[string]interface{}, registry map[string]Schema, namespace string) (Schema, error) {
@@ -1044,7 +1047,11 @@ func parseFixedSchema(v map[string]interface{}, registry map[string]Schema, name
 
 	schema := &FixedSchema{Name: v[schemaNameField].(string), Size: int(size), Properties: getProperties(v)}
 	setOptionalField(&schema.Namespace, v, schemaNamespaceField)
-	return addSchema(getFullName(v[schemaNameField].(string), namespace), schema, registry), nil
+	ns := namespace
+	if schema.Namespace != "" {
+		ns = schema.Namespace
+	}
+	return addSchema(getFullName(v[schemaNameField].(string), ns), schema, registry), nil
 }
 
 func parseUnionSchema(v []interface{}, registry map[string]Schema, namespace string) (Schema, error) {
@@ -1064,7 +1071,11 @@ func parseRecordSchema(v map[string]interface{}, registry map[string]Schema, nam
 	setOptionalField(&schema.Namespace, v, schemaNamespaceField)
 	setOptionalField(&namespace, v, schemaNamespaceField)
 	setOptionalField(&schema.Doc, v, schemaDocField)
-	addSchema(getFullName(v[schemaNameField].(string), namespace), newRecursiveSchema(schema), registry)
+	ns := namespace
+	if schema.Namespace != "" {
+		ns = schema.Namespace
+	}
+	addSchema(getFullName(v[schemaNameField].(string), ns), newRecursiveSchema(schema), registry)
 	fields := make([]*SchemaField, len(v[schemaFieldsField].([]interface{})))
 	for i := range fields {
 		field, err := parseSchemaField(v[schemaFieldsField].([]interface{})[i], registry, namespace)

--- a/schema_test.go
+++ b/schema_test.go
@@ -317,11 +317,13 @@ func TestRecordCustomProps(t *testing.T) {
 
 func TestLoadSchemas(t *testing.T) {
 	schemas := LoadSchemas("test/schemas/")
-	assert(t, len(schemas), 4)
+	assert(t, len(schemas), 5)
 
 	_, exists := schemas["example.avro.Complex"]
 	assert(t, exists, true)
 	_, exists = schemas["example.avro.foo"]
+	assert(t, exists, true)
+	_, exists = schemas["another.example.bar"]
 	assert(t, exists, true)
 }
 

--- a/test/schemas/test_record.avsc
+++ b/test/schemas/test_record.avsc
@@ -31,6 +31,19 @@
          }
       },
       {
+        "name":"namespacedEnumField",
+        "type":{
+           "type":"enum",
+           "namespace":"another.example",
+           "name":"bar",
+           "symbols":[
+              "X",
+              "Y",
+              "Z"
+           ]
+        }
+     },
+      {
          "name":"mapOfInts",
          "type":{
             "type":"map",


### PR DESCRIPTION
As described in spec (1.8.1) individual fields (record, enum and fixed)
can also have its own namespace effectively overriding the enclosing
namespace.